### PR TITLE
メールバリデーションの修正

### DIFF
--- a/lib/custom_fields/validators/email_address_validator.rb
+++ b/lib/custom_fields/validators/email_address_validator.rb
@@ -1,7 +1,7 @@
 module CustomFields
   module Validators
     class EmailAddressValidator < ActiveModel::Validator
-      EMAIL_REGEXP = /\A([\w+\-].?)+@[a-z\d\-]+(\.[a-z\-]+)*\.[a-z]+\z/i
+      EMAIL_REGEXP = /\A[_a-zA-Z0-9\-.~{|}`^?=\/+*’&%$#!]+@[a-z\d\-]+(\.[a-z\-]+)*\.[a-z]+\z/i
       def initialize(options={})
         @opt = options
       end
@@ -23,7 +23,7 @@ module CustomFields
         input_email = r[f]
         e = EmailAddress.new(input_email, host_validation: :syntax, local_format: :standard)
         return r.errors.add(f, :invalid) unless e.valid?
-        
+
         # double check for trailing spaces and unicodes
         return r.errors.add(f, :invalid) unless input_email.match(EMAIL_REGEXP)
       end

--- a/spec/unit/types/email_spec.rb
+++ b/spec/unit/types/email_spec.rb
@@ -38,7 +38,7 @@ describe CustomFields::Types::Email do
       end
     end
 
-    ['foo.fr', 'foo@foo', 'foo.@foo.com', 'foo@foo.com ', 'foo@foo.com  ', 'foo@ｆoo.com'].each do |value|
+    ['foo.fr', 'foo@foo', 'foo.@foo.com', 'foo@foo.com ', 'foo@foo.com  ', 'foo@ｆoo.com', 'fo(o@foo.com', 'fo"o@foo.com'].each do |value|
       it "should not valid if the value is #{value.inspect}" do
         post.email = value
         expect(post.valid?).to eq false


### PR DESCRIPTION
https://doorkel.atlassian.net/browse/SCLC-577

https://zoom.us/signin で確認して見たところ`(`以外に`)`,`"`も使用できなかったので対応しています。
